### PR TITLE
fix: esm requires file extensions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import getStdin from "get-stdin";
 import {
   fromFederatedSDLToValidSDL,
   fromValidSDLToFederatedSDL,
-} from "./convert";
+} from "./convert.js";
 
 const cli = meow(
   `

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -1,7 +1,7 @@
 import {
   fromFederatedSDLToValidSDL,
   fromValidSDLToFederatedSDL,
-} from "../src/convert";
+} from "../src/convert.js";
 
 test("fromFederatedSDLToValidSDL", async () => {
   expect(

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,7 +1,7 @@
 import { readFile } from "fs/promises";
 import execa from "execa";
 import { dirname, resolve } from "path";
-import { fromFederatedSDLToValidSDL } from "../src/convert";
+import { fromFederatedSDLToValidSDL } from "../src/convert.js";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
jest doesn't catch this